### PR TITLE
Added authentication type to constructor of ClaimsIdentity

### DIFF
--- a/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
+++ b/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
@@ -84,7 +84,7 @@ namespace NEasyAuthMiddleware.Core
 
                 _logger.LogTrace($"{nameof(EasyAuthAuthenticationHandler)} found {claims.Count} successful result(s) and mapped them to claims.");
 
-                var identity = new ClaimsIdentity(claims);
+                var identity = new ClaimsIdentity(claims, "EasyAuth");
                 var principal = new ClaimsPrincipal(identity);
                 var ticket = new AuthenticationTicket(principal, Scheme.Name);
 

--- a/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
+++ b/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
@@ -84,7 +84,7 @@ namespace NEasyAuthMiddleware.Core
 
                 _logger.LogTrace($"{nameof(EasyAuthAuthenticationHandler)} found {claims.Count} successful result(s) and mapped them to claims.");
 
-                var identity = new ClaimsIdentity(claims, "EasyAuth");
+                var identity = new ClaimsIdentity(claims, Scheme.Name);
                 var principal = new ClaimsPrincipal(identity);
                 var ticket = new AuthenticationTicket(principal, Scheme.Name);
 


### PR DESCRIPTION
Using this library in a .Net Core 3.1 project and user.Identity.IsAuthenticated is always false. Seems that you must pass an authentication type as well as your claims into the ClaimsIdentity when you create it.

For reference:
https://stackoverflow.com/questions/20254796/why-is-my-claimsidentity-isauthenticated-always-false-for-web-api-authorize-fil

Have set authentication type to "EasyAuth"