### PR TITLE
#12: Register HttpContextAccessor if not exists

### DIFF
--- a/NEasyAuthMiddleware/ServiceBuilderExtensions.cs
+++ b/NEasyAuthMiddleware/ServiceBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using NEasyAuthMiddleware.Constants;
 using NEasyAuthMiddleware.Core;
@@ -12,6 +14,10 @@ namespace NEasyAuthMiddleware
     {
         public static AuthenticationBuilder AddEasyAuth(this AuthenticationBuilder builder, string authenticationScheme, Action<EasyAuthOptions> configure = null)
         {
+            if (!builder.Services.Any(s => typeof(IHttpContextAccessor).IsAssignableFrom(s.ServiceType)))
+            {
+                builder.Services.AddHttpContextAccessor();
+            }
             builder.Services.AddSingleton<IHeaderDictionaryProvider, HttpContextHeaderDictionaryProvider>();
             builder.Services.AddSingleton<IClaimMapper, StandardPrincipalClaimMapper>();
 

--- a/NEasyAuthMiddleware/ServiceBuilderExtensions.cs
+++ b/NEasyAuthMiddleware/ServiceBuilderExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using NEasyAuthMiddleware.Constants;
 using NEasyAuthMiddleware.Core;
@@ -14,10 +12,7 @@ namespace NEasyAuthMiddleware
     {
         public static AuthenticationBuilder AddEasyAuth(this AuthenticationBuilder builder, string authenticationScheme, Action<EasyAuthOptions> configure = null)
         {
-            if (!builder.Services.Any(s => typeof(IHttpContextAccessor).IsAssignableFrom(s.ServiceType)))
-            {
-                builder.Services.AddHttpContextAccessor();
-            }
+            builder.Services.AddHttpContextAccessor();
             builder.Services.AddSingleton<IHeaderDictionaryProvider, HttpContextHeaderDictionaryProvider>();
             builder.Services.AddSingleton<IClaimMapper, StandardPrincipalClaimMapper>();
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Just add the following to your `Startup.cs`
 ```csharp
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddHttpContextAccessor();
             services.AddEasyAuth();
 
             if (_hostingEnvironment.IsDevelopment()) // Use the mock json file when not running in an app service


### PR DESCRIPTION
This PR addresses issue #12 by automatically registering `IHttpContextAccessor` if it hasn't already been registered. This still allows the user the flexibility to register their own if they wish.