### PR TITLE
Upgrading to netcoreapp8.0

### DIFF
--- a/NEasyAuthMiddleware.Sample/NEasyAuthMiddleware.Sample.csproj
+++ b/NEasyAuthMiddleware.Sample/NEasyAuthMiddleware.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
     <UserSecretsId>c20c33a7-f76c-4e31-b823-cb63c0302b88</UserSecretsId>
   </PropertyGroup>
 

--- a/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
+++ b/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
@@ -7,8 +7,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
-using NEasyAuthMiddleware.Providers;
 
 namespace NEasyAuthMiddleware.Core
 {
@@ -26,8 +24,7 @@ namespace NEasyAuthMiddleware.Core
             IEnumerable<IClaimsTransformer> claimsTransformers,
             IOptionsMonitor<EasyAuthOptions> options,
             ILoggerFactory logger,
-            UrlEncoder encoder,
-            ISystemClock clock) : base(options, logger, encoder, clock)
+            UrlEncoder encoder) : base(options, logger, encoder)
         {
             _claimsTransformers = claimsTransformers.ToList();
             _headerDictionaryTransformers = headerDictionaryTransformers.ToList();

--- a/NEasyAuthMiddleware/NEasyAuthMiddleware.csproj
+++ b/NEasyAuthMiddleware/NEasyAuthMiddleware.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>1.0.1</Version>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <Version>3.0.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Dasith Wijesiriwardena</Authors>
     <Copyright>2019</Copyright>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ NEasyAuthMiddleware does all of this complicated logic for you and keeps your au
 
 - Version 1.X targets AspNet Core 2.x
 - Version 2.X targets AspNet Core 3.x
+- Version 3.x targets AspNet Core 8.x
 
 Install the package using NuGet Package Manager Console
 


### PR DESCRIPTION
The library references a long-deprecated version of .NET ☹️ This PR simply modernizes it.