### PR TITLE
#11: Adding ability to handle Challenges and SignOut

### DIFF
--- a/NEasyAuthMiddleware.sln
+++ b/NEasyAuthMiddleware.sln
@@ -5,7 +5,14 @@ VisualStudioVersion = 15.0.28307.271
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NEasyAuthMiddleware", "NEasyAuthMiddleware\NEasyAuthMiddleware.csproj", "{9E0305C5-E80F-45A5-A21A-DE5F8EA181A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NEasyAuthMiddleware.Sample", "NEasyAuthMiddleware.Sample\NEasyAuthMiddleware.Sample.csproj", "{FBC0D4C3-7663-4C35-BF0D-DF0492AFA675}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NEasyAuthMiddleware.Sample", "NEasyAuthMiddleware.Sample\NEasyAuthMiddleware.Sample.csproj", "{FBC0D4C3-7663-4C35-BF0D-DF0492AFA675}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AFFF8A96-4B9A-4151-A58F-175C948E199C}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/NEasyAuthMiddleware/Constants/KnownAuthProviders.cs
+++ b/NEasyAuthMiddleware/Constants/KnownAuthProviders.cs
@@ -1,0 +1,15 @@
+﻿namespace NEasyAuthMiddleware.Constants
+{
+    /// <summary>
+    /// List of known providers for EasyAuth, taken from <see cref="https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#identity-providers">official docs</see>
+    /// </summary>
+    public static class KnownAuthProviders
+    {
+        public const string Apple = "apple";
+        public const string MicrosoftEntra = "aad";
+        public const string Facebook = "facebook";
+        public const string GitHub = "github";
+        public const string Google = "google";
+        public const string Twitter = "twitter";
+    }
+}

--- a/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
+++ b/NEasyAuthMiddleware/Core/EasyAuthAuthenticationHandler.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -12,7 +13,7 @@ using NEasyAuthMiddleware.Providers;
 
 namespace NEasyAuthMiddleware.Core
 {
-    public class EasyAuthAuthenticationHandler : AuthenticationHandler<EasyAuthOptions>
+    public class EasyAuthAuthenticationHandler : SignOutAuthenticationHandler<EasyAuthOptions>
     {
         private readonly IList<IHeaderDictionaryProvider> _headerDictionaryProviders;
         private readonly IList<IClaimMapper> _claimMappers;
@@ -94,6 +95,18 @@ namespace NEasyAuthMiddleware.Core
 
             _logger.LogTrace($"{nameof(EasyAuthAuthenticationHandler)} did not find any successful results.");
             return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        protected override Task HandleChallengeAsync(AuthenticationProperties properties) 
+        {
+            Response.Redirect($"/.auth/login/{Options.Provider}?post_login_redirect_uri={Request.GetEncodedPathAndQuery()}");
+            return Task.CompletedTask;
+        }
+
+        protected override Task HandleSignOutAsync(AuthenticationProperties properties)
+        {
+            Response.Redirect("/.auth/logout");
+            return Task.CompletedTask;
         }
     }
 }

--- a/NEasyAuthMiddleware/Core/EasyAuthOptions.cs
+++ b/NEasyAuthMiddleware/Core/EasyAuthOptions.cs
@@ -6,7 +6,10 @@ namespace NEasyAuthMiddleware.Core
 {
     public class EasyAuthOptions : AuthenticationSchemeOptions
     {
-        public string Provider { get; set; } = "aad";
+        /// <summary>
+        /// The provider to use for authentication. Default is <see cref="KnownAuthProviders.MicrosoftEntra"/>.
+        /// </summary>
+        public string Provider { get; set; } = KnownAuthProviders.MicrosoftEntra;
         public IList<string> IgnoreClaimTypes { get; set; } = new List<string>();
         public IList<string> ClaimTypesWithCommaSeparatedValues { get; set; } = new List<string>() { KnownEasyAuthClaimAliases.Roles };
     }

--- a/NEasyAuthMiddleware/Core/EasyAuthOptions.cs
+++ b/NEasyAuthMiddleware/Core/EasyAuthOptions.cs
@@ -6,6 +6,7 @@ namespace NEasyAuthMiddleware.Core
 {
     public class EasyAuthOptions : AuthenticationSchemeOptions
     {
+        public string Provider { get; set; } = "aad";
         public IList<string> IgnoreClaimTypes { get; set; } = new List<string>();
         public IList<string> ClaimTypesWithCommaSeparatedValues { get; set; } = new List<string>() { KnownEasyAuthClaimAliases.Roles };
     }

--- a/README.md
+++ b/README.md
@@ -86,17 +86,19 @@ Azure App Services allows you to configure EasyAuth to allow unauthenticated req
 
 This library supports this scenario. If you've specified `AddAuthorization()` to the service collection, and added `UseAuthorization()` to the middleware pipeline, the library will automatically redirect users to login with EasyAuth on controllers attributed with `[Authorize]`.
 
-By default the library assumes AAD auth, but you can customize the [provider](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#identity-providers) using `EasyAuthOptions` when adding the service.
+By default the library assumes AAD/Microsoft Entra auth, but you can customize the [provider](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#identity-providers) using `EasyAuthOptions` when adding the service.
 
 ```csharp
 		public void ConfigureServices(IServiceCollection services)
 		{
 			services.AddEasyAuth(options =>
 			{
-				options.Provider = "google"; // Use Google as the auth provider
+				options.Provider = KnownAuthProviders.Google; // Use Google as the auth provider
 			});
 		}
 ```
+
+> NOTE: The library provides a list of known providers in the `NEasyAuthMiddleware.Constants.KnownAuthProviders` static class.
 
 ## Customizing it
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Just add the following to your `Startup.cs`
             services.AddHttpContextAccessor();
             services.AddEasyAuth();
 
+            // Add this if you want your app to support [automatic Challenges](#handling-unauthenticated-requests)
+            services.AddAuthorization();
+
             if (_hostingEnvironment.IsDevelopment()) // Use the mock json file when not running in an app service
             {
                 var mockFile = $"{_hostingEnvironment.ContentRootPath}\\mock_user.json";
@@ -53,6 +56,8 @@ Just add the following to your `Startup.cs`
         {
             app.UseAuthentication(); // Indicate we are using the Authenticaiton middleware
             app.UseRouting();
+
+            // Add this if you want your app to support [automatic Challenges](#handling-unauthenticated-requests)
             app.UseAuthorization(); // This has to come between routing and endoints
 
             app.UseEndpoints(endpoints =>
@@ -75,6 +80,23 @@ In your controller, use the `Authorize` attribute as you would with any other au
 ```
 
 See the [sample app](https://github.com/dasiths/NEasyAuthMiddleware/tree/master/NEasyAuthMiddleware.Sample) for more.
+
+## Handling unauthenticated requests
+Azure App Services allows you to configure EasyAuth to allow unauthenticated requests to pass through to your application. This is useful when you want to handle authentication in your application code, or only enable it for certain pages or flows. 
+
+This library supports this scenario. If you've specified `AddAuthorization()` to the service collection, and added `UseAuthorization()` to the middleware pipeline, the library will automatically redirect users to login with EasyAuth on controllers attributed with `[Authorize]`.
+
+By default the library assumes AAD auth, but you can customize the [provider](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#identity-providers) using `EasyAuthOptions` when adding the service.
+
+```csharp
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddEasyAuth(options =>
+			{
+				options.Provider = "google"; // Use Google as the auth provider
+			});
+		}
+```
 
 ## Customizing it
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Azure App Services allows you to configure EasyAuth to allow unauthenticated req
 
 This library supports this scenario. If you've specified `AddAuthorization()` to the service collection, and added `UseAuthorization()` to the middleware pipeline, the library will automatically redirect users to login with EasyAuth on controllers attributed with `[Authorize]`.
 
-By default the library assumes AAD/Microsoft Entra auth, but you can customize the [provider](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#identity-providers) using `EasyAuthOptions` when adding the service.
+By default the library assumes AAD/Microsoft Entra auth, but you can customize the [provider](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#identity-providers) using `EasyAuthOptions` when adding the service. The library provides a list of known providers in the `NEasyAuthMiddleware.Constants.KnownAuthProviders` static class.
 
 ```csharp
 		public void ConfigureServices(IServiceCollection services)
@@ -97,8 +97,6 @@ By default the library assumes AAD/Microsoft Entra auth, but you can customize t
 			});
 		}
 ```
-
-> NOTE: The library provides a list of known providers in the `NEasyAuthMiddleware.Constants.KnownAuthProviders` static class.
 
 ## Customizing it
 


### PR DESCRIPTION
* Addresses issue #11 by adding handlers to support Challenges and SignOuts in the EasyAuth framework.
    * User can specify their auth provider in `EasyAuthOptions`
* Update README to reflect capability.
* As a convenience, adding a Solution Items folder to the .sln for editing things like the README directly in VS.